### PR TITLE
Desenv enums actions

### DIFF
--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpBaseRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpBaseRequest.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains methods that assembles client and request to call endpoints
+    /// </summary>
     public abstract class HttpBaseRequest
     {
         /// <summary>
@@ -22,20 +25,20 @@ namespace QATestingCore.IntegratedTests.ActionsHandler
         /// </summary>
         /// <param name="baseUrl">Represents the host endpoint URL</param>
         /// <param name="resourcePath">Represents the path of the resource inside the endpoint server</param>
-        /// <param name="method">Represents the http verb that the call will execute on the endpoint</param>
+        /// <param name="EnumMethod">Represents the http verb that the call will execute on the endpoint</param>
         /// <param name="dataFormat">Represents the data type expected as response by the endipoint json or xml</param>
         /// <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request. Obs.:It is considered null value when it were omitted</param>
         /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
         protected void Arrange(string baseUrl,
                                string resourcePath,
-                               Method method,
+                               HttpMethod EnumMethod,
                                DataFormat dataFormat,
                                JObject paramsBody = null,
                                string token = null)
         {
             RestClient = new RestClient(baseUrl);
 
-            RestRequest = new RestRequest(resourcePath, method, dataFormat);
+            RestRequest = new RestRequest(resourcePath, (Method)EnumMethod, dataFormat);
 
             if (paramsBody != null)
             {

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpDeleteRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpDeleteRequest.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action DEL
+    /// </summary>
     public class HttpDelRequest : HttpBaseRequest, IHttpDelRequest
     {
         /// <summary>
@@ -13,7 +16,7 @@ namespace QATestingCore.IntegratedTests.ActionsHandler
         /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
         /// <returns>Return an IRestResponse object</returns>
         public IRestResponse MakeDeleteRequest(UriBuilder uriBuilder,
-                                               Method method = Method.DELETE,
+                                               HttpMethod method = HttpMethod.DELETE,
                                                string token = null)
         {
             var baseUrl = AssembleBaseUrl(uriBuilder);

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpGetRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpGetRequest.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action GET
+    /// </summary>
     public class HttpGetRequest : HttpBaseRequest, IHttpGetRequest
     {
         /// <summary>
@@ -13,7 +16,7 @@ namespace QATestingCore.IntegratedTests.ActionsHandler
         /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
         /// <returns>Return an IRestResponse object</returns>
         public IRestResponse MakeGetRequest(UriBuilder uriBuilder,
-                                            Method method = Method.GET,
+                                            HttpMethod method = HttpMethod.GET,
                                             string token = null)
         {
             var baseUrl = AssembleBaseUrl(uriBuilder);

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpMethod.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpMethod.cs
@@ -1,0 +1,45 @@
+﻿namespace QATestingCore.IntegratedTests.ActionsHandler
+{
+    /// <summary>
+    /// Enum 
+    /// </summary>
+    public enum HttpMethod
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        GET = 0,
+        /// <summary>
+        /// 
+        /// </summary>
+        POST = 1,
+        /// <summary>
+        /// 
+        /// </summary>
+        PUT = 2,
+        /// <summary>
+        /// 
+        /// </summary>
+        DELETE = 3,
+        /// <summary>
+        /// 
+        /// </summary>
+        HEAD = 4,
+        /// <summary>
+        /// 
+        /// </summary>
+        OPTIONS = 5,
+        /// <summary>
+        /// 
+        /// </summary>
+        PATCH = 6,
+        /// <summary>
+        /// 
+        /// </summary>
+        MERGE = 7,
+        /// <summary>
+        /// 
+        /// </summary>
+        COPY = 8
+    }
+}

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpMethod.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpMethod.cs
@@ -1,44 +1,44 @@
 ﻿namespace QATestingCore.IntegratedTests.ActionsHandler
 {
     /// <summary>
-    /// Enum 
+    /// Contain the enums that matches the restsharp enum
     /// </summary>
     public enum HttpMethod
     {
         /// <summary>
-        /// 
+        /// Represent the method GET
         /// </summary>
         GET = 0,
         /// <summary>
-        /// 
+        /// Represent the method POST
         /// </summary>
         POST = 1,
         /// <summary>
-        /// 
+        /// Represent the method PUT
         /// </summary>
         PUT = 2,
         /// <summary>
-        /// 
+        /// Represent the method DELETE
         /// </summary>
         DELETE = 3,
         /// <summary>
-        /// 
+        /// Represent the method HEAD
         /// </summary>
         HEAD = 4,
         /// <summary>
-        /// 
+        /// Represent the method OPTION
         /// </summary>
         OPTIONS = 5,
         /// <summary>
-        /// 
+        /// Represent the method PATCH
         /// </summary>
         PATCH = 6,
         /// <summary>
-        /// 
+        /// Represent the method MERGE
         /// </summary>
         MERGE = 7,
         /// <summary>
-        /// 
+        /// Represent the method COPY
         /// </summary>
         COPY = 8
     }

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpPostRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpPostRequest.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action POST
+    /// </summary>
     public class HttpPostRequest : HttpBaseRequest, IHttpPostRequest
     {
         /// <summary>
@@ -21,7 +24,7 @@ namespace QATestingCore.IntegratedTests.ActionsHandler
 
             Arrange(baseUrl,
                     uriBuilder.Uri.LocalPath,
-                    Method.POST,
+                    HttpMethod.POST,
                     DataFormat.Json,
                     paramsBody,
                     token);

--- a/QATestingCore.IntegratedTests/ActionsHandler/HttpPutRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/HttpPutRequest.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action PUT
+    /// </summary>
     public class HttpPutRequest : HttpBaseRequest, IHttpPutRequest
     {
         /// <summary>
@@ -21,7 +24,7 @@ namespace QATestingCore.IntegratedTests.ActionsHandler
 
             Arrange(baseUrl,
             uriBuilder.Uri.LocalPath,
-            Method.PUT,
+            HttpMethod.PUT,
             DataFormat.Json,
             paramsBody,
             token);

--- a/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpDelRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpDelRequest.cs
@@ -3,8 +3,18 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action DEL
+    /// </summary>
     public interface IHttpDelRequest
     {
-        IRestResponse MakeDeleteRequest(UriBuilder uriBuilder, Method method = Method.DELETE, string token = null);
+        /// <summary>
+        /// Create Delete request and execute the call to an endpoint
+        /// </summary>
+        /// <param name="uriBuilder">Represents an object that contains client and request informations</param>
+        /// <param name="method">Represents an objects with the parameters to be sent wrapped into the request</param>
+        /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+        /// <returns>Return an IRestResponse object</returns>
+        IRestResponse MakeDeleteRequest(UriBuilder uriBuilder, HttpMethod method = HttpMethod.DELETE, string token = null);
     }
 }

--- a/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpGetRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpGetRequest.cs
@@ -3,8 +3,18 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action GET
+    /// </summary>
     public interface IHttpGetRequest
     {
-        IRestResponse MakeGetRequest(UriBuilder uri, Method method = Method.GET, string token = null);
+        /// <summary>
+        /// Create Get request and execute the call to an endpoint
+        /// </summary>
+        /// <param name="uriBuilder">Represents an object that contains client and request informations</param>
+        /// <param name="method">Represents an objects with the parameters to be sent wrapped into the request</param>
+        /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+        /// <returns>Return an IRestResponse object</returns>
+        IRestResponse MakeGetRequest(UriBuilder uriBuilder, HttpMethod method = HttpMethod.GET, string token = null);
     }
 }

--- a/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpPostRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpPostRequest.cs
@@ -4,8 +4,18 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action POST
+    /// </summary>
     public interface IHttpPostRequest
     {
+        /// <summary>
+        /// Create Post request and execute the call to an endpoint
+        /// </summary>
+        /// <param name="uriBuilder">Represents an object that contains client and request informations</param>
+        /// <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request</param>
+        /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+        /// <returns>Return an IRestResponse object</returns>
         IRestResponse MakePostRequet(UriBuilder uriBuilder, 
                                      JObject paramsBody, 
                                      string token = null);

--- a/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpPutRequest.cs
+++ b/QATestingCore.IntegratedTests/ActionsHandler/Interfaces/IHttpPutRequest.cs
@@ -4,8 +4,18 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.ActionsHandler
 {
+    /// <summary>
+    /// Contains method to beget call to the endpoint as Http action PUT
+    /// </summary>
     public interface IHttpPutRequest
     {
+        /// <summary>
+        /// Create PUT request and execute the call to an endpoint
+        /// </summary>
+        /// <param name="uriBuilder">Represents an object that contains client and request informations</param>
+        /// <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request</param>
+        /// <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+        /// <returns>Return an IRestResponse object</returns>
         IRestResponse MakePutRequest(UriBuilder uriBuilder, 
                                      JObject paramsBody, 
                                      string token = null);

--- a/QATestingCore.IntegratedTests/Assertions/ResponseContentAssertions.cs
+++ b/QATestingCore.IntegratedTests/Assertions/ResponseContentAssertions.cs
@@ -4,6 +4,9 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.Assertions
 {
+    /// <summary>
+    /// Contain method to assert json shema comparing actual object to expected object schema
+    /// </summary>
     public static class ResponseContentAssertions 
     {
         /// <summary>
@@ -12,7 +15,7 @@ namespace QATestingCore.IntegratedTests.Assertions
         /// <typeparam name="T">Represents a JObject of type T</typeparam>
         /// <param name="response">Represents a IRestResponse object with the content to be asserted</param>
         /// <param name="expectedResult">Represents a JObject of type T containing the expected parameters</param>
-        /// <returns></returns>
+        /// <returns>Returns a boolean value to be asserted True=success or an exception will return</returns>
         public static bool AssertResponseDataObject<T>(IRestResponse response, T expectedResult)
         {
             var result = JObject.Parse(response.Content).ToObject<T>();

--- a/QATestingCore.IntegratedTests/Assertions/SchemaAssertions.cs
+++ b/QATestingCore.IntegratedTests/Assertions/SchemaAssertions.cs
@@ -4,6 +4,9 @@ using RestSharp;
 
 namespace QATestingCore.IntegratedTests.Assertions
 {
+    /// <summary>
+    /// Contain method to assert json shema comparing actual object to expected object schema
+    /// </summary>
     public static class SchemaAssertions
     {
         /// <summary>

--- a/QATestingCore.IntegratedTests/Assertions/StatusCodeAssertions.cs
+++ b/QATestingCore.IntegratedTests/Assertions/StatusCodeAssertions.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
+﻿using System.Net;
 
 namespace QATestingCore.IntegratedTests.Assertions
 {
+    /// <summary>
+    /// Contains methods to assert statuscode of call's responses
+    /// </summary>
     public static class StatusCodeAssertions
     {
         /// <summary>

--- a/QATestingCore.IntegratedTests/Authentications/Interfaces/IJWTAuthentication.cs
+++ b/QATestingCore.IntegratedTests/Authentications/Interfaces/IJWTAuthentication.cs
@@ -4,8 +4,17 @@ using System.Threading.Tasks;
 
 namespace QATestingCore.IntegratedTests.Authentications
 {
+    /// <summary>
+    /// Create the UriBuilder object in memory
+    /// </summary>
     public interface IJWTAuthentication
     {
+        /// <summary>
+        /// Generate oauth token through an authentication server asynchronously
+        /// </summary>
+        /// <param name="uriBuilder">Represents an object that contains client and request informations</param>
+        /// <param name="paramsObj">Represents an objects with the parameters to be sent wrapped into the request</param>
+        /// <returns>Returns a token sent for the oauth authentication server</returns>
         string GetOauthAuthentication(UriBuilder uriBuilder, JObject paramsObj);
     }
 }

--- a/QATestingCore.IntegratedTests/Authentications/JWTAuthentication.cs
+++ b/QATestingCore.IntegratedTests/Authentications/JWTAuthentication.cs
@@ -8,6 +8,9 @@ using System.Threading.Tasks;
 
 namespace QATestingCore.IntegratedTests.Authentications
 {
+    /// <summary>
+    /// Contains methods to beget token authentication as JWT security
+    /// </summary>
     public class JWTAuthentication : HttpBaseRequest, IJWTAuthentication
     {
         private UriBuilder uriBuilder;
@@ -32,7 +35,7 @@ namespace QATestingCore.IntegratedTests.Authentications
 
             Arrange(baseUrl,
                     uriBuilder.Uri.LocalPath,
-                    Method.GET,
+                    HttpMethod.GET,
                     DataFormat.Json,
                     paramsObj);
 

--- a/QATestingCore.IntegratedTests/Authentications/RSAAuthentication.cs
+++ b/QATestingCore.IntegratedTests/Authentications/RSAAuthentication.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace QATestingCore.IntegratedTests.Authentications
 {
+    /// <summary>
+    /// Class to access authentication server as RSA concept.
+    /// </summary>
     public class RSAAuthentication
     {
     }

--- a/QATestingCore.IntegratedTests/QATestingCore.IntegratedTests.xml
+++ b/QATestingCore.IntegratedTests/QATestingCore.IntegratedTests.xml
@@ -4,6 +4,11 @@
         <name>QATestingCore.IntegratedTests</name>
     </assembly>
     <members>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpBaseRequest">
+            <summary>
+            Contains methods that assembles client and request to call endpoints
+            </summary>
+        </member>
         <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpBaseRequest.RestClient">
             <summary>
             RestClient object of RestSharp library
@@ -14,13 +19,13 @@
             restRequest object of RestSharp library
             </summary>
         </member>
-        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpBaseRequest.Arrange(System.String,System.String,RestSharp.Method,RestSharp.DataFormat,Newtonsoft.Json.Linq.JObject,System.String)">
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpBaseRequest.Arrange(System.String,System.String,QATestingCore.IntegratedTests.ActionsHandler.HttpMethod,RestSharp.DataFormat,Newtonsoft.Json.Linq.JObject,System.String)">
             <summary>
             Arrange the request to call the endpoint
             </summary>
             <param name="baseUrl">Represents the host endpoint URL</param>
             <param name="resourcePath">Represents the path of the resource inside the endpoint server</param>
-            <param name="method">Represents the http verb that the call will execute on the endpoint</param>
+            <param name="EnumMethod">Represents the http verb that the call will execute on the endpoint</param>
             <param name="dataFormat">Represents the data type expected as response by the endipoint json or xml</param>
             <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request. Obs.:It is considered null value when it were omitted</param>
             <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
@@ -44,7 +49,12 @@
             <param name="uriBuilder"></param>
             <returns></returns>
         </member>
-        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpDelRequest.MakeDeleteRequest(System.UriBuilder,RestSharp.Method,System.String)">
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpDelRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action DEL
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpDelRequest.MakeDeleteRequest(System.UriBuilder,QATestingCore.IntegratedTests.ActionsHandler.HttpMethod,System.String)">
             <summary>
             Create Delete request and execute the call to an endpoint
             </summary>
@@ -53,7 +63,12 @@
             <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
             <returns>Return an IRestResponse object</returns>
         </member>
-        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpGetRequest.MakeGetRequest(System.UriBuilder,RestSharp.Method,System.String)">
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpGetRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action GET
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpGetRequest.MakeGetRequest(System.UriBuilder,QATestingCore.IntegratedTests.ActionsHandler.HttpMethod,System.String)">
             <summary>
             Create Get request and execute the call to an endpoint
             </summary>
@@ -61,6 +76,61 @@
             <param name="method">Represents an objects with the parameters to be sent wrapped into the request</param>
             <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
             <returns>Return an IRestResponse object</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod">
+            <summary>
+            Enum 
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.GET">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.POST">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.PUT">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.DELETE">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.HEAD">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.OPTIONS">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.PATCH">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.MERGE">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="F:QATestingCore.IntegratedTests.ActionsHandler.HttpMethod.COPY">
+            <summary>
+            
+            </summary>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpPostRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action POST
+            </summary>
         </member>
         <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpPostRequest.MakePostRequet(System.UriBuilder,Newtonsoft.Json.Linq.JObject,System.String)">
             <summary>
@@ -71,6 +141,11 @@
             <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
             <returns>Return an IRestResponse object</returns>
         </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.HttpPutRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action PUT
+            </summary>
+        </member>
         <member name="M:QATestingCore.IntegratedTests.ActionsHandler.HttpPutRequest.MakePutRequest(System.UriBuilder,Newtonsoft.Json.Linq.JObject,System.String)">
             <summary>
             Create PUT request and execute the call to an endpoint
@@ -80,6 +155,67 @@
             <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
             <returns>Return an IRestResponse object</returns>
         </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.IHttpDelRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action DEL
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.IHttpDelRequest.MakeDeleteRequest(System.UriBuilder,QATestingCore.IntegratedTests.ActionsHandler.HttpMethod,System.String)">
+            <summary>
+            Create Delete request and execute the call to an endpoint
+            </summary>
+            <param name="uriBuilder">Represents an object that contains client and request informations</param>
+            <param name="method">Represents an objects with the parameters to be sent wrapped into the request</param>
+            <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+            <returns>Return an IRestResponse object</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.IHttpGetRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action GET
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.IHttpGetRequest.MakeGetRequest(System.UriBuilder,QATestingCore.IntegratedTests.ActionsHandler.HttpMethod,System.String)">
+            <summary>
+            Create Get request and execute the call to an endpoint
+            </summary>
+            <param name="uriBuilder">Represents an object that contains client and request informations</param>
+            <param name="method">Represents an objects with the parameters to be sent wrapped into the request</param>
+            <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+            <returns>Return an IRestResponse object</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.IHttpPostRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action POST
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.IHttpPostRequest.MakePostRequet(System.UriBuilder,Newtonsoft.Json.Linq.JObject,System.String)">
+            <summary>
+            Create Post request and execute the call to an endpoint
+            </summary>
+            <param name="uriBuilder">Represents an object that contains client and request informations</param>
+            <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request</param>
+            <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+            <returns>Return an IRestResponse object</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.ActionsHandler.IHttpPutRequest">
+            <summary>
+            Contains method to beget call to the endpoint as Http action PUT
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.ActionsHandler.IHttpPutRequest.MakePutRequest(System.UriBuilder,Newtonsoft.Json.Linq.JObject,System.String)">
+            <summary>
+            Create PUT request and execute the call to an endpoint
+            </summary>
+            <param name="uriBuilder">Represents an object that contains client and request informations</param>
+            <param name="paramsBody">Represents an objects with the parameters to be sent wrapped into the request</param>
+            <param name="token">Represents the key informed. Obs.:It is considered null value when it were omitted</param>
+            <returns>Return an IRestResponse object</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.Assertions.ResponseContentAssertions">
+            <summary>
+            Contain method to assert json shema comparing actual object to expected object schema
+            </summary>
+        </member>
         <member name="M:QATestingCore.IntegratedTests.Assertions.ResponseContentAssertions.AssertResponseDataObject``1(RestSharp.IRestResponse,``0)">
             <summary>
             Assert the content from the response to the content expected
@@ -87,7 +223,12 @@
             <typeparam name="T">Represents a JObject of type T</typeparam>
             <param name="response">Represents a IRestResponse object with the content to be asserted</param>
             <param name="expectedResult">Represents a JObject of type T containing the expected parameters</param>
-            <returns></returns>
+            <returns>Returns a boolean value to be asserted True=success or an exception will return</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.Assertions.SchemaAssertions">
+            <summary>
+            Contain method to assert json shema comparing actual object to expected object schema
+            </summary>
         </member>
         <member name="M:QATestingCore.IntegratedTests.Assertions.SchemaAssertions.ValidateJsonSchema(System.String,RestSharp.IRestResponse)">
             <summary>
@@ -97,6 +238,11 @@
             <param name="response">Represents a IRestResponse object with the content to be asserted</param>
             <returns>Returns a boolean value to be asserted</returns>
         </member>
+        <member name="T:QATestingCore.IntegratedTests.Assertions.StatusCodeAssertions">
+            <summary>
+            Contains methods to assert statuscode of call's responses
+            </summary>
+        </member>
         <member name="M:QATestingCore.IntegratedTests.Assertions.StatusCodeAssertions.AssertStatusCode(System.Net.HttpStatusCode,System.Net.HttpStatusCode)">
             <summary>
             Compare the statuscode received to the statuscode expected
@@ -104,6 +250,24 @@
             <param name="statusCode">Represents the status code got from response being validated</param>
             <param name="expectedStatusCode">Represents the expected status code</param>
             <returns>Returns a boolean data to be asserted</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.Authentications.IJWTAuthentication">
+            <summary>
+            Create the UriBuilder object in memory
+            </summary>
+        </member>
+        <member name="M:QATestingCore.IntegratedTests.Authentications.IJWTAuthentication.GetOauthAuthentication(System.UriBuilder,Newtonsoft.Json.Linq.JObject)">
+            <summary>
+            Generate oauth token through an authentication server asynchronously
+            </summary>
+            <param name="uriBuilder">Represents an object that contains client and request informations</param>
+            <param name="paramsObj">Represents an objects with the parameters to be sent wrapped into the request</param>
+            <returns>Returns a token sent for the oauth authentication server</returns>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.Authentications.JWTAuthentication">
+            <summary>
+            Contains methods to beget token authentication as JWT security
+            </summary>
         </member>
         <member name="M:QATestingCore.IntegratedTests.Authentications.JWTAuthentication.#ctor">
             <summary>
@@ -118,18 +282,28 @@
             <param name="paramsObj">Represents an objects with the parameters to be sent wrapped into the request</param>
             <returns>Returns a token sent for the oauth authentication server</returns>
         </member>
+        <member name="T:QATestingCore.IntegratedTests.Authentications.RSAAuthentication">
+            <summary>
+            Class to access authentication server as RSA concept.
+            </summary>
+        </member>
+        <member name="T:QATestingCore.IntegratedTests.TestUtils.RetrieveTestData">
+            <summary>
+            Contains methods to retrive test data from json files as different format responses
+            </summary>
+        </member>
         <member name="M:QATestingCore.IntegratedTests.TestUtils.RetrieveTestData.GetResourceAsString(System.String)">
             <summary>
             Read data from file json and returns data as string
             </summary>
-            <param name="filePath">Represents the value from the parameter <see cref="!:filePath"/> where it is stowed</param>
+            <param name="filePath">Represents the value from the parameter where it is stowed</param>
             <returns>Returns a string object containing the data read from json file</returns>
         </member>
         <member name="M:QATestingCore.IntegratedTests.TestUtils.RetrieveTestData.GetResourceAsJObject(System.String)">
             <summary>
             Read data from file json and returns data as Json Object
             </summary>
-            <param name="filePath">Represents the value from the parameter <see cref="!:filePath"/> where it is stowed</param>
+            <param name="filePath">Represents the value from the parameter where it is stowed</param>
             <returns>Returns a string object containing the data read from json file</returns>
         </member>
         <member name="M:QATestingCore.IntegratedTests.TestUtils.RetrieveTestData.GetResourceAsGeneric``1(System.String)">
@@ -137,7 +311,7 @@
             Read data from file json and returns data object as Model Class
             </summary>
             <typeparam name="T">Represents the Model Class as type T</typeparam>
-            <param name="filePath">Represents the value from the parameter <see cref="!:filePath"/> where it is stowed</param>
+            <param name="filePath">Represents the value from the parameter where it is stowed Ex.: @"\folder\filename.json"</param>
             <returns></returns>
         </member>
         <!-- Badly formed XML comment ignored for member "M:QATestingCore.IntegratedTests.TestUtils.RetrieveTestData.GetRequestParameters``1(System.String,System.String)" -->

--- a/QATestingCore.IntegratedTests/TestUtils/RetrieveTestData.cs
+++ b/QATestingCore.IntegratedTests/TestUtils/RetrieveTestData.cs
@@ -5,12 +5,15 @@ using System.IO;
 
 namespace QATestingCore.IntegratedTests.TestUtils
 {
+    /// <summary>
+    /// Contains methods to retrive test data from json files as different format responses
+    /// </summary>
     public static class RetrieveTestData
     {
         /// <summary>
         /// Read data from file json and returns data as string
         /// </summary>
-        /// <param name="filePath">Represents the value from the parameter <see cref="filePath"/> where it is stowed</param>
+        /// <param name="filePath">Represents the value from the parameter where it is stowed Ex.: @"\folder\filename.json"</param>
         /// <returns>Returns a string object containing the data read from json file</returns>
         public static string GetResourceAsString(string filePath)
         {
@@ -29,7 +32,7 @@ namespace QATestingCore.IntegratedTests.TestUtils
         /// <summary>
         /// Read data from file json and returns data as Json Object
         /// </summary>
-        /// <param name="filePath">Represents the value from the parameter <see cref="filePath"/> where it is stowed</param>
+        /// <param name="filePath">Represents the value from the parameter where it is stowed Ex.: @"\folder\filename.json"</param>
         /// <returns>Returns a string object containing the data read from json file</returns>
         public static JObject GetResourceAsJObject(string filePath)
         {
@@ -49,7 +52,7 @@ namespace QATestingCore.IntegratedTests.TestUtils
         /// Read data from file json and returns data object as Model Class
         /// </summary>
         /// <typeparam name="T">Represents the Model Class as type T</typeparam>
-        /// <param name="filePath">Represents the value from the parameter <see cref="filePath"/> where it is stowed</param>
+        /// <param name="filePath">Represents the value from the parameter where it is stowed Ex.: @"\folder\filename.json"</param>
         /// <returns></returns>
         public static T GetResourceAsGeneric<T>(string filePath)
         {
@@ -68,9 +71,8 @@ namespace QATestingCore.IntegratedTests.TestUtils
         /// <summary>
         /// Read Json file and extract information through a JToken informed and that represents a Model Class
         /// </summary>
-        /// <typeparam name="T">Represents the Model Class as type <ModelClassName></T></typeparam>
-        /// <param name="filePath">Represents the value from the parameter <see cref="filePath"/> where it is stowed</param>
-        /// <param name="jsonTokenName">Represents the name of the Json property</param>
+        /// <param name="filePath">Represents the value from the parameter where it is stowed Ex.: Ex.: @"\folder\filename.json"</param>
+        /// <param name="jsonTokenName">Represents the name of the Json property ex.: "T01234"</param>
         /// <returns></returns>
         public static object GetRequestParameters<T>(string filePath, string jsonTokenName)
         {

--- a/XUnitTestProject/ObjectTest/ValuesControllerIntegratedTest.cs
+++ b/XUnitTestProject/ObjectTest/ValuesControllerIntegratedTest.cs
@@ -125,7 +125,7 @@ namespace XUnitTestProject.ObjectTest
             var _jwtToken = _oauthAuthentication.GetOauthAuthentication(oauthURI, paramsBody);
 
             //Act   
-            var response = _httpGetRequest.MakeGetRequest(testURI, RestSharp.Method.GET,_jwtToken);
+            var response = _httpGetRequest.MakeGetRequest(testURI, HttpMethod.GET, _jwtToken);
 
             //Assert
             var result = StatusCodeAssertions.AssertStatusCode(response.StatusCode, expectedResult);
@@ -142,7 +142,7 @@ namespace XUnitTestProject.ObjectTest
             var expectedObj = RetrieveTestData.GetResourceAsGeneric<ParamsBodyTest>(expectBodyParams);
 
             //Act
-            var response = _httpGetRequest.MakeGetRequest(testURI, RestSharp.Method.GET);
+            var response = _httpGetRequest.MakeGetRequest(testURI, HttpMethod.GET);
 
             //Assert
             ResponseContentAssertions.AssertResponseDataObject<ParamsBodyTest>(response, expectedObj);

--- a/XUnitTestProject/XUnitTestProject.csproj
+++ b/XUnitTestProject/XUnitTestProject.csproj
@@ -25,12 +25,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="RestSharp" Version="106.6.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Inclusão dos enums para HttpMethod passando a não usar o enum do restsharp.
retirada da library Restsharp, Newtonsoft e FluentAssertions do projeto de teste.
Inserção de Documentação nos métodos e classes.